### PR TITLE
Use public repo count instead of count of repositories from `/repos`

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -110,7 +110,7 @@ async function getGitHubStats(username: string) {
   return { 
     userData,
     stats: {
-      totalRepos: reposData.length,
+      totalRepos: userData.public_repos,
       totalStars,
       totalForks,
       mostActiveDay,


### PR DESCRIPTION
When a user has more than 100 repositories, the `/repos` endpoint can only return 100 on the first page. Rather than adding pagination handling, this patch just uses the `public_repos` value from the user data api call as the value for `totalRepos`.